### PR TITLE
Adds parallelization of request to wxyc api for a speed boost.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,18 +5,18 @@ build-backend = "hatchling.build"
 [project]
 name = "wxyc-discogs"
 version = "0.1.0"
-description = "A command-line tool for searching Discogs and checking WXYC library status"
+description = "A tool to search Discogs and check WXYC library status"
 readme = "README.md"
 requires-python = ">=3.8"
 license = "GPL-3.0-or-later"
 authors = [
-    { name = "Your Name", email = "your.email@example.com" }
+    { name = "WXYC", email = "adrian@abruno.dev" }
 ]
 dependencies = [
     "requests>=2.31.0",
     "python-dotenv>=1.0.0",
     "curses-menu>=0.5.0",
-    "jwt>=1.3.1"
+    "jwt>=1.3.1",
 ]
 
 [project.scripts]


### PR DESCRIPTION
Also adds new command [w]xyc to switch to a view of wxyc library results for the requested artist to cross reference against if the list retrived from Discogs.

From my testing it cut the time to retrieve a full list of 5 discogs releases by half from 8.8s to 4.2s